### PR TITLE
fix: removed invalid aaName condition in consent-artefact fetch

### DIFF
--- a/fiul-aa-webclient/src/main/java/io/finarkein/fiul/aa/SignedConsentArtefactFetcher.java
+++ b/fiul-aa-webclient/src/main/java/io/finarkein/fiul/aa/SignedConsentArtefactFetcher.java
@@ -43,8 +43,6 @@ public class SignedConsentArtefactFetcher implements RequestUpdater.DigitalSignU
 
     @Override
     public boolean updateIfNeededAndCache(DigitalSigConsumer consumer, String aaName) {
-        if(!aaName.equalsIgnoreCase("finvu"))
-            return false;
         String signedConsentArtefact = cache.getIfSignedConsentArtefactPresent(consumer.getId());
         if (signedConsentArtefact == null) {
             try {


### PR DESCRIPTION
- It was added initially for one-money sandbox test flow, for one-money uat it is no longer needed
