### PR TITLE
fix: setting fix v061, getConsentState api fix

### DIFF
--- a/fiul-aa-webclient/pom.xml
+++ b/fiul-aa-webclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-core/pom.xml
+++ b/fiul-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-rest/fiul-rest-app/pom.xml
+++ b/fiul-rest/fiul-rest-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul-rest</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-rest/fiul-rest-consent/pom.xml
+++ b/fiul-rest/fiul-rest-consent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul-rest</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-rest/fiul-rest-dataflow/pom.xml
+++ b/fiul-rest/fiul-rest-dataflow/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul-rest</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-rest/fiul-rest-notification/pom.xml
+++ b/fiul-rest/fiul-rest-notification/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul-rest</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-rest/pom.xml
+++ b/fiul-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/fiul-service-consent/pom.xml
+++ b/fiul-service-consent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/service/ConsentService.java
+++ b/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/service/ConsentService.java
@@ -35,7 +35,7 @@ public interface ConsentService {
 
     void handleConsentNotification(ConsentNotificationLog consentNotificationLog);
 
-    Mono<ConsentStateDTO> getConsentState(String consentHandle, Optional<String> customerAAId);
+    Mono<ConsentStateDTO> getConsentState(String consentHandle, Optional<String> aaHandle);
 
     ConsentStateDTO getConsentStateByConsentId(String consentId);
 

--- a/fiul-service-dataflow/fiul-dataflow-core/pom.xml
+++ b/fiul-service-dataflow/fiul-dataflow-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul-service-dataflow</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/impl/ConsentServiceClientImpl.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/impl/ConsentServiceClientImpl.java
@@ -18,6 +18,8 @@ import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
+import static io.finarkein.api.aa.util.Functions.aaNameExtractor;
+
 @Service
 public class ConsentServiceClientImpl implements ConsentServiceClient {
 
@@ -55,7 +57,8 @@ public class ConsentServiceClientImpl implements ConsentServiceClient {
 
     @Override
     public Mono<ConsentStateDTO> getConsentState(String consentHandle, Optional<String> customerAAId) {
-        return consentService.getConsentState(consentHandle, customerAAId);
+        final Optional<String> aaHandle = customerAAId.map(aaNameExtractor);
+        return consentService.getConsentState(consentHandle, aaHandle);
     }
 
     @Override

--- a/fiul-service-dataflow/fiul-dataflow-default-impl/pom.xml
+++ b/fiul-service-dataflow/fiul-dataflow-default-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul-service-dataflow</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-dataflow/fiul-dataflow-fi-data-crypto-no-op/pom.xml
+++ b/fiul-service-dataflow/fiul-dataflow-fi-data-crypto-no-op/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul-service-dataflow</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-dataflow/fiul-dataflow-notification-subscriber/pom.xml
+++ b/fiul-service-dataflow/fiul-dataflow-notification-subscriber/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul-service-dataflow</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-dataflow/pom.xml
+++ b/fiul-service-dataflow/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-notification/fiul-notification-callback-core/pom.xml
+++ b/fiul-service-notification/fiul-notification-callback-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul-service-notification</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-notification/fiul-notification-callbacks-in-mem-sub/pom.xml
+++ b/fiul-service-notification/fiul-notification-callbacks-in-mem-sub/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul-service-notification</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-notification/fiul-notification-callbacks-jpa/pom.xml
+++ b/fiul-service-notification/fiul-notification-callbacks-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul-service-notification</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-notification/fiul-notification-core/pom.xml
+++ b/fiul-service-notification/fiul-notification-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.finarkein.fiu</groupId>
         <artifactId>fiul-service-notification</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-notification/fiul-notification-in-mem-config/pom.xml
+++ b/fiul-service-notification/fiul-notification-in-mem-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul-service-notification</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-notification/fiul-notification-in-mem-pub/pom.xml
+++ b/fiul-service-notification/fiul-notification-in-mem-pub/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul-service-notification</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fiul-service-notification/pom.xml
+++ b/fiul-service-notification/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fiul</artifactId>
         <groupId>io.finarkein.fiu</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.finarkein.fiu</groupId>
     <artifactId>fiul</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.6.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
- getConsentState api expects aaHandle as input but at one place customerAAId was passed without extracting aaHandle. Issue is reproducible only when fiul instance does not have aaHandle for given consentHandle in database i.e. consent was not raised on the current instance