### PR TITLE
Feature/timestamp with zone persistence

### DIFF
--- a/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentNotificationLog.java
+++ b/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentNotificationLog.java
@@ -32,7 +32,7 @@ public class ConsentNotificationLog {
     private String version;
     private String txnId;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp notificationTimestamp;
 
     private String notifierType;
@@ -42,7 +42,7 @@ public class ConsentNotificationLog {
     private String consentState;
     private String aaId;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentRequestDTO.java
+++ b/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentRequestDTO.java
@@ -40,7 +40,10 @@ public class ConsentRequestDTO {
     private String consentId;
     private String txnId;
     private String version;
+
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp timestamp;
+    
     private String aaName;
     private String customerId;
 

--- a/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentRequestDTO.java
+++ b/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentRequestDTO.java
@@ -44,10 +44,10 @@ public class ConsentRequestDTO {
     private String aaName;
     private String customerId;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp consentStartDate;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp consentEndDate;
 
     private ConsentMode consentMode;
@@ -65,17 +65,17 @@ public class ConsentRequestDTO {
     @Basic(fetch = javax.persistence.FetchType.LAZY)
     private List<DataFilter> dataFilterJson;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp fiDateRangeFrom;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp fiDateRangeTo;
 
     private FetchType fetchType;
     private String frequencyUnit;
     private int frequencyValue;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentStateDTO.java
+++ b/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentStateDTO.java
@@ -42,10 +42,10 @@ public class ConsentStateDTO {
     private String notifierId;
 
     @LastModifiedDate
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp updatedOn;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp postConsentResponseTimestamp;
 
     @PrePersist

--- a/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentTemplate.java
+++ b/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/model/ConsentTemplate.java
@@ -33,11 +33,11 @@ public class ConsentTemplate {
     @Convert(converter = ConsentJsonAttrConverter.OfTypeConsentTemplateDefinition.class)
     private ConsentTemplateDefinition consentTemplateDefinition;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp createdOn;
 
     @LastModifiedDate
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp updatedOn;
 
     @PrePersist

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/AAFIDatum.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/AAFIDatum.java
@@ -56,10 +56,10 @@ public class AAFIDatum {
     @Convert(converter = ZippedBlobAttrConverter.OfKeyMaterial.class)
     private KeyMaterial keyMaterial;
 
-    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE", nullable = false, updatable = false)
     private Timestamp dataLifeExpireOn;
 
-    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE", nullable = false, updatable = false)
     private Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FIDataHeader.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FIDataHeader.java
@@ -56,10 +56,10 @@ public class FIDataHeader {
     @Column(nullable = false, updatable = false)
     private Integer dataLifeValue;
 
-    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE", nullable = false, updatable = false)
     private Timestamp dataLifeExpireOn;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FIFetchMetadata.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FIFetchMetadata.java
@@ -53,13 +53,13 @@ public class FIFetchMetadata {
     @Column(columnDefinition = "boolean default false")
     protected boolean easyDataFlow;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp fiDataRangeFrom;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp fiDataRangeTo;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp fiRequestSubmittedOn;
 
     @Column(length = 36)
@@ -68,13 +68,13 @@ public class FIFetchMetadata {
     @Column(length = 36)
     protected String linkRefNumbers;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp fiFetchSubmittedOn;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp fiFetchCompletedOn;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp updatedOn;
 
     @PrePersist

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FINotificationLogEntry.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FINotificationLogEntry.java
@@ -33,7 +33,7 @@ public class FINotificationLogEntry {
     protected long id;
 
     protected String version;
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp notificationTimestamp;
 
     protected String txnId;
@@ -46,7 +46,7 @@ public class FINotificationLogEntry {
     @Convert(converter = Converter.OfFIStatusResponseList.class)
     protected List<FIStatusResponse> fiStatusNotification;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FIRequestDTO.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FIRequestDTO.java
@@ -44,17 +44,17 @@ public class FIRequestDTO {
 
     protected String version;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp timestamp;
 
     protected String txnId;
 
     protected String aaName;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp fiDataRangeFrom;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp fiDataRangeTo;
 
     @Column(columnDefinition="text")
@@ -65,7 +65,7 @@ public class FIRequestDTO {
     @Convert(converter = JSONAttrConverter.OfCallback.class)
     protected Callback callback;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FIRequestState.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/dto/FIRequestState.java
@@ -44,17 +44,17 @@ public class FIRequestState {
     protected String txnId;
     protected String aaId;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp fiRequestSubmittedOn;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp notificationTimestamp;
 
     @Column(columnDefinition = "text")
     @Convert(converter = Converter.OfFIStatusResponseDTOSet.class)
     protected Set<FIStatusResponseDTO> fiStatusResponse;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp updatedOn;
 
     @PrePersist

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/easy/dto/FIDataRecord.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/easy/dto/FIDataRecord.java
@@ -54,10 +54,10 @@ public final class FIDataRecord {
     @Column(columnDefinition="BYTEA", nullable = false, updatable = false)
     private byte[] fiData;
 
-    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE", nullable = false, updatable = false)
     private Timestamp dataLifeExpireOn;
 
-    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE", nullable = false, updatable = false)
     private Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/easy/dto/FIDataRecordDataKey.java
+++ b/fiul-service-dataflow/fiul-dataflow-core/src/main/java/io/finarkein/fiul/dataflow/easy/dto/FIDataRecordDataKey.java
@@ -46,10 +46,10 @@ public final class FIDataRecordDataKey {
     @Column(nullable = false, updatable = false)
     private byte[] encryptedDataKey;
 
-    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE", nullable = false, updatable = false)
     private Timestamp dataLifeExpireOn;
 
-    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE", nullable = false, updatable = false)
     private Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-notification/fiul-notification-callback-core/src/main/java/io/finarkein/fiul/notification/callback/model/ConsentCallback.java
+++ b/fiul-service-notification/fiul-notification-callback-core/src/main/java/io/finarkein/fiul/notification/callback/model/ConsentCallback.java
@@ -23,7 +23,7 @@ public class ConsentCallback {
     protected String consentHandleId;
     protected String callbackUrl;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp createdOn;
 
     @PrePersist

--- a/fiul-service-notification/fiul-notification-callback-core/src/main/java/io/finarkein/fiul/notification/callback/model/FICallback.java
+++ b/fiul-service-notification/fiul-notification-callback-core/src/main/java/io/finarkein/fiul/notification/callback/model/FICallback.java
@@ -30,7 +30,7 @@ public class FICallback {
     protected String consentId;
     protected String callbackUrl;
 
-    @Column(columnDefinition = "TIMESTAMP(6)")
+    @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp createdOn;
 
     @PrePersist


### PR DESCRIPTION
For current deployments when any data is persisted with timestamp column, values inserted are considered to be in local timezone of JVM running(i.e. fiul JVM)

Run following queries to alter column data types to TIMESTAMP with TIME ZONE,

> ALTER TABLE Consent_Notification_Log ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE Consent_Notification_Log ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE Consent_Notification_Log ALTER COLUMN notification_Timestamp TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_template ALTER COLUMN updated_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_template ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_requestdto ALTER COLUMN consent_start_date TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_requestdto ALTER COLUMN consent_end_date TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_requestdto ALTER COLUMN fi_date_range_from TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_requestdto ALTER COLUMN fi_date_range_to TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_requestdto ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_requestdto ALTER COLUMN timestamp TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_state ALTER COLUMN updated_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE consent_state ALTER COLUMN post_Consent_Response_Timestamp TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_DATUM ALTER COLUMN data_Life_Expire_On TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_DATUM ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_DATA_HEADER ALTER COLUMN data_Life_Expire_On TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_DATA_HEADER ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_FETCH_METADATA ALTER COLUMN updated_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_FETCH_METADATA ALTER COLUMN fi_data_range_from TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_FETCH_METADATA ALTER COLUMN fi_data_range_to TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_FETCH_METADATA ALTER COLUMN fi_Request_Submitted_On TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_FETCH_METADATA ALTER COLUMN fi_Fetch_Submitted_On TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_FETCH_METADATA ALTER COLUMN fi_Fetch_Completed_On TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_NOTIFICATION_LOG ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_NOTIFICATION_LOG ALTER COLUMN notification_Timestamp TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_REQUEST ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_REQUEST ALTER COLUMN fi_Data_Range_From TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_REQUEST ALTER COLUMN fi_Data_Range_To TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_REQUEST ALTER COLUMN timestamp TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_REQUEST_STATE ALTER COLUMN updated_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_REQUEST_STATE ALTER COLUMN notification_Timestamp TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_REQUEST_STATE ALTER COLUMN fi_Request_Submitted_On TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_DATA_RECORD ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_DATA_RECORD ALTER COLUMN data_Life_Expire_On TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_DATA_RECORD_KEY ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_DATA_RECORD_KEY ALTER COLUMN data_Life_Expire_On TYPE timestamp WITH TIME ZONE;
> ALTER TABLE Consent_Callback ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;
> ALTER TABLE FI_CALLBACK ALTER COLUMN created_on TYPE timestamp WITH TIME ZONE;