### PR TITLE
Feature/consent callback add on params

### DIFF
--- a/fiul-core/src/main/java/io/finarkein/fiul/dataflow/DataRequest.java
+++ b/fiul-core/src/main/java/io/finarkein/fiul/dataflow/DataRequest.java
@@ -9,6 +9,7 @@ package io.finarkein.fiul.dataflow;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.finarkein.fiul.ext.Callback;
 import lombok.*;
 
@@ -92,8 +93,8 @@ public class DataRequest {
         }
 
         @JsonProperty("callback")
-        public DataRequest.Builder callbackURL(@NonNull final String url) {
-            this.callback = new Callback(url);
+        public DataRequest.Builder callbackURL(@NonNull final String url, final JsonNode addOnParams) {
+            this.callback = new Callback(url, addOnParams);
             return this;
         }
 

--- a/fiul-core/src/main/java/io/finarkein/fiul/ext/Callback.java
+++ b/fiul-core/src/main/java/io/finarkein/fiul/ext/Callback.java
@@ -9,13 +9,15 @@ package io.finarkein.fiul.ext;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-        "url"
+        "url",
+        "addOnParams"
 })
 @Data
 @AllArgsConstructor
@@ -24,5 +26,7 @@ public class Callback {
 
     @JsonProperty("url")
     private String url;
-    
+
+    @JsonProperty("addOnParams")
+    private JsonNode addOnParams;
 }

--- a/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/impl/ConsentServiceImpl.java
+++ b/fiul-service-consent/src/main/java/io/finarkein/fiul/consent/impl/ConsentServiceImpl.java
@@ -78,6 +78,7 @@ class ConsentServiceImpl implements ConsentService {
                             var callback = new ConsentCallback();
                             callback.setConsentHandleId(response.getConsentHandle());
                             callback.setCallbackUrl(consentRequest.getCallback().getUrl());
+                            callback.setAddOnParams(consentRequest.getCallback().getAddOnParams());
                             callbackRegistry.registerConsentCallback(callback);
                         }
                 ).doOnSuccess(response -> {

--- a/fiul-service-notification/fiul-notification-callback-core/pom.xml
+++ b/fiul-service-notification/fiul-notification-callback-core/pom.xml
@@ -44,7 +44,14 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.vladmihalcea</groupId>
+            <artifactId>hibernate-types-52</artifactId>
+            <version>2.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
     </dependencies>
-
-
 </project>

--- a/fiul-service-notification/fiul-notification-callback-core/src/main/java/io/finarkein/fiul/notification/callback/impl/CallbackProcessorImpl.java
+++ b/fiul-service-notification/fiul-notification-callback-core/src/main/java/io/finarkein/fiul/notification/callback/impl/CallbackProcessorImpl.java
@@ -14,13 +14,20 @@ import io.finarkein.fiul.notification.callback.CallbackProcessor;
 import io.finarkein.fiul.notification.callback.CallbackRegistry;
 import io.finarkein.fiul.notification.callback.model.ConsentCallback;
 import io.finarkein.fiul.notification.callback.model.FICallback;
+import io.netty.handler.ssl.SslHandshakeTimeoutException;
+import io.netty.handler.timeout.TimeoutException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Set;
 
@@ -37,6 +44,15 @@ public class CallbackProcessorImpl implements CallbackProcessor {
 
     protected final CallbackRegistry registry;
     protected final WebClient webClient;
+
+    @Value("${consent.callback.retry.count:3}")
+    private int consentCallbackRetryCount;
+
+    @Value("${consent.callback.timeout.in.seconds:10}")
+    private int consentCallbackTimeoutInSeconds;
+
+    @Value("${consent.callback.retry.delay.seconds:5}")
+    private int consentCallbackRetryDelayInSeconds;
 
     @Autowired
     protected CallbackProcessorImpl(@Qualifier(WEBHOOK_QUALIFIER_SUPPLIER_METHOD) WebClient webClient,
@@ -71,7 +87,38 @@ public class CallbackProcessorImpl implements CallbackProcessor {
             webClient.post()
                     .uri(callback.getCallbackUrl())
                     .body(Mono.just(statusNotification), ConsentStatusNotification.class)
-                    .exchange().block();
+                    .retrieve()
+                    .onStatus(
+                            status -> status.is5xxServerError() || status.value() == 408 || status.value() == 429,
+                            response -> {
+                                String message = String.format("Error %d-%s, while sending consent status " +
+                                                "notification, object is '%s'",
+                                        response.rawStatusCode(), response.statusCode().getReasonPhrase(),
+                                        statusNotification);
+                                return Mono.error(new CallbackServiceException(message));
+                            })
+                    .bodyToMono(String.class)
+                    .timeout(Duration.ofSeconds(consentCallbackTimeoutInSeconds))
+
+                    .onErrorMap(java.util.concurrent.TimeoutException.class, ex -> logAndCreateException("java.util.concurrent.TimeoutException", ex))
+                    .onErrorMap(TimeoutException.class, ex -> logAndCreateException("Channel TimeoutException", ex))
+                    .onErrorMap(SslHandshakeTimeoutException.class, ex -> logAndCreateException("SslHandshakeTimeout", ex))
+                    .onErrorMap(WebClientRequestException.class, ex -> logAndCreateException("WebClientRequestException", ex))
+
+                    .subscribeOn(Schedulers.boundedElastic())
+                    .publishOn(Schedulers.boundedElastic())
+                    .doOnSuccess(string -> log.debug("Notification sent Successfully {} :" +
+                            " response string is '{}'", statusNotification, string))
+                    .doOnError(error -> log.error("Failed to send notification {}", statusNotification, error))
+                    .retryWhen(
+                            Retry.backoff(consentCallbackRetryCount, Duration.ofSeconds(consentCallbackRetryDelayInSeconds))
+                                    .jitter(0.6)
+                                    .filter(throwable -> throwable instanceof CallbackServiceException)
+                                    .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) ->
+                                            new IllegalStateException(
+                                                    "Failed to send consent notification to '" + callback.getCallbackUrl() + "'" +
+                                                            " after " + retrySignal.totalRetries() + " attempts, notification object : " + statusNotification)))
+                    .subscribe();
         } catch (Exception e) {
             log.error("Error while calling ConsentCallback on notification:{}, callback-url:{}", statusNotification,
                     callback.getCallbackUrl(), e);
@@ -126,5 +173,16 @@ public class CallbackProcessorImpl implements CallbackProcessor {
             }
         }
         log.debug("FINotification handling done, notification:{}", notification);
+    }
+
+    private Throwable logAndCreateException(String message, Throwable error) {
+        log.debug("Encountered '{}' error while calling external callback api : ", message, error);
+        return new CallbackServiceException(message);
+    }
+
+    static class CallbackServiceException extends Exception {
+        CallbackServiceException(String message) {
+            super(message);
+        }
     }
 }

--- a/fiul-service-notification/fiul-notification-callback-core/src/main/java/io/finarkein/fiul/notification/callback/model/ConsentCallback.java
+++ b/fiul-service-notification/fiul-notification-callback-core/src/main/java/io/finarkein/fiul/notification/callback/model/ConsentCallback.java
@@ -6,7 +6,11 @@
  */
 package io.finarkein.fiul.notification.callback.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.vladmihalcea.hibernate.type.json.JsonType;
 import lombok.Data;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,6 +21,7 @@ import java.time.Instant;
 
 @Data
 @Entity
+@TypeDef(name = "json", typeClass = JsonType.class)
 public class ConsentCallback {
 
     @Id
@@ -25,6 +30,10 @@ public class ConsentCallback {
 
     @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     protected Timestamp createdOn;
+
+    @Type(type = "json")
+    @Column(name = "add_on_params", columnDefinition = "jsonb")
+    private JsonNode addOnParams;
 
     @PrePersist
     protected void onCreate() {

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version.spring-webflux>5.3.8</version.spring-webflux>
         <version.maven-dependency-plugin>3.1.1</version.maven-dependency-plugin>
         <version.logger>2.17.1</version.logger>
-        <version.aa-commons>0.5.6-SNAPSHOT</version.aa-commons>
+        <version.aa-commons>0.5.6</version.aa-commons>
         <version.fi-meta>1.0.4</version.fi-meta>
 
         <version.maven-compiler>3.8.1</version.maven-compiler>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version.spring-webflux>5.3.8</version.spring-webflux>
         <version.maven-dependency-plugin>3.1.1</version.maven-dependency-plugin>
         <version.logger>2.17.1</version.logger>
-        <version.aa-commons>0.5.3</version.aa-commons>
+        <version.aa-commons>0.5.6-SNAPSHOT</version.aa-commons>
         <version.fi-meta>1.0.4</version.fi-meta>
 
         <version.maven-compiler>3.8.1</version.maven-compiler>


### PR DESCRIPTION
## Description

Added support for sending additional parameters in consent callbacks 

## Motivation and Context

Callers who are expecting callbacks when consent state changes can now configure a json object that should be delivered in each notification



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
